### PR TITLE
add alternative paths with single slashes

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -182,6 +182,8 @@ async fn app() -> Result<bool> {
     let api = Router::new()
         .nest("//auth", api_auth::router()) // => /api//auth ¯\_(ツ)_/¯
         .nest("//assets", api_assets::router())
+        .nest("/auth", api_auth::router())
+        .nest("/assets", api_assets::router())
         .nest("/v1", api::sculptor::router(limit))
         .route("/limits", get(api_info::limits))
         .route("/version", get(api_info::version))


### PR DESCRIPTION
I noticed the latest version of the mod is NOT querying `/api//auth` but `/api/auth`. *Probably* the `/api//assets` should also be `/api/assets` now.

I added two new paths instead of changing the existing routings for compatibility. I don't know how the mod behaved earlier, but without this change I could not get the server to work with the latest version of Figura.